### PR TITLE
Var name typo fix

### DIFF
--- a/drivers/roomba980/finder.js
+++ b/drivers/roomba980/finder.js
@@ -79,7 +79,7 @@ class RoombaFinder extends Homey.SimpleClass {
                 });
 
                 this.listenServer.bind(5678, () => {
-                    this.listeningg = true;
+                    this.listening = true;
 
                     const message = new Buffer('irobotmcs');
 


### PR DESCRIPTION
I believe this is causing issues when you have multiple Roomba devices, rendering the app unusable. Thanks.