### PR TITLE
Fixing EADDRINUSE issue and combining with #12 and #13 - working code with 3 Roombas

### DIFF
--- a/drivers/roomba980/device.js
+++ b/drivers/roomba980/device.js
@@ -84,46 +84,33 @@ class Roomba980Device extends Homey.Device {
                 this.error(`Error in Roomba connection: ${e}`);
             });
 
-            this.robot.on('state', (e) => {
-                if (typeof e.batPct !== 'undefined') {
-                    this.setCapabilityValue('measure_battery', e.batPct)
-                        .catch(this.error.bind('measure_battery', e.batPct));
+            this.robot.on('state', (state) => {
+                if (typeof state.batPct !== 'undefined') {
+                    this.setCapabilityValue('measure_battery', state.batPct)
+                        .catch(this.error.bind('measure_battery', state.batPct));
                 }
 
-                let cycle = e.cleanMissionStatus.cycle,
-                    phase = e.cleanMissionStatus.phase;
+                let cycle = state.cleanMissionStatus.cycle,
+                    phase = state.cleanMissionStatus.phase;
 
                 if (cycle === 'none' && phase === 'charge') {
-                    if (typeof e.batPct !== 'undefined' && e.batPct < 100) {
+                    if (typeof state.batPct !== 'undefined' && state.batPct < 100) {
                         this.setCapabilityValue('vacuumcleaner_state', 'charging')
                             .catch(this.error.bind('vacuumcleaner_state charging'));
                     } else {
                         this.setCapabilityValue('vacuumcleaner_state', 'docked')
                             .catch(this.error.bind('vacuumcleaner_state docked'));
                     }
-                }
-
-                if (cycle === 'none' && phase === 'stop') {
+                } else if (cycle === ('none' || 'quick') && phase === 'stop') {
                     this.setCapabilityValue('vacuumcleaner_state', 'stopped')
                         .catch(this.error.bind('vacuumcleaner_state stopped'));
-                }
-
-                if (cycle === 'dock' && phase === 'hmUsrDock') {
+                } else if (cycle === 'dock' && phase === 'hmUsrDock') {
                     this.setCapabilityValue('vacuumcleaner_state', 'docked')
                         .catch(this.error.bind('vacuumcleaner_state docked'));
-                }
-
-                if (cycle === 'quick' && phase === 'stop') {
-                    this.setCapabilityValue('vacuumcleaner_state', 'stopped')
-                        .catch(this.error.bind('vacuumcleaner_state stopped'));
-                }
-
-                if (cycle === 'quick' && phase === 'run') {
+                } else if (cycle === 'quick' && phase === 'run') {
                     this.setCapabilityValue('vacuumcleaner_state', 'cleaning')
                         .catch(this.error.bind('vacuumcleaner_state cleaning'));
-                }
-
-                if (cycle === 'spot' && phase === 'run') {
+                } else if (cycle === 'spot' && phase === 'run') {
                     this.setCapabilityValue('vacuumcleaner_state', 'spot_cleaning')
                         .catch(this.error.bind('vacuumcleaner_state spot_cleaning'));
                 }

--- a/drivers/roomba980/finder.js
+++ b/drivers/roomba980/finder.js
@@ -79,7 +79,7 @@ class RoombaFinder extends Homey.SimpleClass {
                 });
 
                 this.listenServer.bind(5678, () => {
-                    this.listeningg = true;
+                    this.listening = true;
 
                     const message = new Buffer('irobotmcs');
 

--- a/drivers/roomba980/finder.js
+++ b/drivers/roomba980/finder.js
@@ -26,7 +26,10 @@ class RoombaFinder extends Homey.SimpleClass {
             const roombas = [];
 
             const nextStep = () => {
-                this.listenServer = dgram.createSocket('udp4');
+                this.listenServer = dgram.createSocket({
+                    type: 'udp4',
+                    reuseAddr: true
+                });
 
                 const timeout = setTimeout(() => {
                     this.listenServer.close(() => {


### PR DESCRIPTION
This PR includes a few things, but is the code that I have now got running successfully on my Homey.
1. The good work of @MatthewWaanders in #12 - changes to parsing of state to guarantee only one state change.
2. The bug fix from my own PR #13 - just a variable name typo fix.
3. Fixing an issue which causes `EADDRINUSE` errors when attempting to bind to port `5689`. I believe this is only an issue when you have multiple Roomba's so it won't affect everyone. With my change here, this is now running ok with 3 Roombas. This fix is the `dgram.createSocket()` part. The stack trace of the error here is below:

```
2018-03-03 15:02:58 [err] [ManagerDrivers] [roomba980] [1] { Error: bind EADDRINUSE 0.0.0.0:5678
    at Object._errnoException (util.js:1041:11)
    at _exceptionWithHostPort (util.js:1064:20)
    at _handle.lookup (dgram.js:242:18)
    at HomeyClient._onMessage (/opt/homey-client/system/manager/ManagerApps/bootstrap/sdk/v2/lib/HomeyClient.js:1:1368)
    at emitTwo (events.js:125:13)
    at process.emit (events.js:213:7)
    at emit (internal/child_process.js:774:12)
    at _combinedTickCallback (internal/process/next_tick.js:141:11)
    at process._tickCallback (internal/process/next_tick.js:180:9)
  code: 'EADDRINUSE',
  errno: 'EADDRINUSE',
  syscall: 'bind',
  address: '0.0.0.0',
  port: 5678 }

dgram.js:598
    throw new 
```

If this can be merged soon and a new app version released that would be much appreciated so I can move back onto the app store version. Thank you.